### PR TITLE
Make cloud functions check based on player id instead of entire object

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -178,7 +178,7 @@ function processPreferenceList (preferenceList, league, leagueId) {
 
         if (lumpedPicks) console.log(`We have ${lumpedPicks.length} picks so far.`)
         // remove array from preferenceList
-        unclaimedPlayers = _.differenceWith(players, lumpedPicks, _.isEqual)
+        unclaimedPlayers = _.differenceWith(players, lumpedPicks, (a, b) => a.id === b.id)
         console.log(`We have ${players.length} players total.`)
         unclaimedPreference = preferenceList ? unclaimedPlayers.filter(o1 => preferenceList.some(o2 => o1.name === o2.name)) : [];
         const missingType = findMissing(rawPicks, userId)


### PR DESCRIPTION
It was checking against the entire player object.  This gets f'd up if the player object changes mid-draft.