### PR TITLE
remove captain requirement from render

### DIFF
--- a/src/views/ManageFantasyTeam.vue
+++ b/src/views/ManageFantasyTeam.vue
@@ -15,7 +15,7 @@
         section
           collapsible(title-text="Your Next Match")
             my-schedule(:leagueId="leagueId")
-      .column(v-if="lineUp.captain && playersLoaded")
+      .column(v-if="playersLoaded")
         section
           h1 Manage Your Fantasy Team
           p The captain role is (for now) just a flex role so you can have a player outside of the 2/2/2 we're enforcing.  Their points will count the same as any other role, so it's safe to feature your favorite DPS as your captain!


### PR DESCRIPTION
Left over from when players were objects.  Had a check on captain because it was an object.