### PR TITLE
rule so league size can not go above 10

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -58,7 +58,7 @@ service cloud.firestore {
 
     match /standardLeagueRoster/{leagueId} {
     	allow read;
-    	allow write: if request.auth.uid != null;
+    	allow write: if request.auth.uid != null && if request.resource.data.size < 11
     }
 
     match /standardLeagueTrades/{leagueId} {


### PR DESCRIPTION
firestore rule to not allow more than 10 people to exist in a standard league